### PR TITLE
Polish: VeilCore x $stimothy cleanup + hero/about/token/live ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Glitchcore single-page site for **VeilCore** promoting the **Stimothy Pumps ($st
 - **VeilCore** is the creator-first collective behind the site and all visual branding.
 - **Stimothy Pumps ($stimothy)** is the featured token; copy throughout the page references the ticker and coin lore.
 - The hero, live badge, and clipboard actions all use `$stimothy` by default—update the copy if the ticker changes.
-- VeilCore.us is the canonical domain; all deployment steps and meta tags reference the VeilCore home base.
+- **VeilCore.us is the canonical domain.** All deployment steps and meta tags reference the VeilCore home base.
 
 ## Replacing visuals
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Glitchcore single-page site for **VeilCore** promoting the **Stimothy Pumps ($st
 - **VeilCore** is the creator-first collective behind the site and all visual branding.
 - **Stimothy Pumps ($stimothy)** is the featured token; copy throughout the page references the ticker and coin lore.
 - The hero, live badge, and clipboard actions all use `$stimothy` by default—update the copy if the ticker changes.
+- **veilcore.us** is the canonical domain; all deployment steps and meta tags reference the VeilCore home base.
 
 ## Replacing visuals
 
@@ -41,6 +42,7 @@ setLive('YOUR_EMBED_URL');
 
 - Call `setLive` once you know the live embed URL (e.g., Pump.fun stream), either in `script.js` or via an inline script after the page loads (`window.setLive('https://example.com/embed')`).
 - The helper stores the URL, reveals the **NOW LIVE** badge, and swaps the placeholder for an `<iframe>` as soon as the section is visible.
+- `setLive` is exported from `script.js`, so you can import it in other modules or trigger it from the console while testing embeds.
 - Remove or replace the placeholder note below the embed card if the stream should appear immediately on load.
 
 ## Local development

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Glitchcore single-page site for **VeilCore** promoting the **Stimothy Pumps ($st
 - **VeilCore** is the creator-first collective behind the site and all visual branding.
 - **Stimothy Pumps ($stimothy)** is the featured token; copy throughout the page references the ticker and coin lore.
 - The hero, live badge, and clipboard actions all use `$stimothy` by default—update the copy if the ticker changes.
-- **veilcore.us** is the canonical domain; all deployment steps and meta tags reference the VeilCore home base.
+- VeilCore.us is the canonical domain; all deployment steps and meta tags reference the VeilCore home base.
 
 ## Replacing visuals
 
@@ -64,6 +64,12 @@ setLive('YOUR_EMBED_URL');
 
 - When you ship updates, append a version query to static assets in `index.html`, e.g. `styles.css?v=2024-05-17`.
 - Alternatively, rename files (`styles.v2.css`, `script.v2.js`) so GitHub Pages serves the latest bundle without relying on stale browser caches.
+
+## Links
+
+- Telegram: https://t.me/stimothypumps
+- X/Twitter community: https://x.com/majorleague_dev/status/1968142661879206385?s=61
+- ConspiraAI: https://conspiraai.com
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# VeilCore Landing — Stimothy Pumps ($stimothy)
+
+Glitchcore single-page site for **VeilCore** promoting the **Stimothy Pumps ($stimothy)** coin. The page ships as semantic HTML, modern CSS, and vanilla JavaScript with motion-aware glitch effects that power the hero, live embed, and resource sections.
+
+## Project structure
+
+```
+├── index.html      # Landing page markup and accessible section structure
+├── styles.css      # Glitchcore theme, layout system, neon utilities
+├── script.js       # Smooth scroll, clipboard toast, live embed helpers
+├── stimothy.png    # Temporary 1:1 coin artwork placeholder
+└── assets/         # Reserved for future imagery (kept empty intentionally)
+```
+
+## Brand & coin context
+
+- **VeilCore** is the creator-first collective behind the site and all visual branding.
+- **Stimothy Pumps ($stimothy)** is the featured token; copy throughout the page references the ticker and coin lore.
+- The hero, live badge, and clipboard actions all use `$stimothy` by default—update the copy if the ticker changes.
+
+## Replacing visuals
+
+### Wordmark placeholder
+- Locate the `TODO` comment inside the `.wordmark` element in `index.html`.
+- Swap the placeholder text with the final VeilCore SVG or `<img>` tag once the asset is ready.
+- If using an inline SVG, keep the `aria-label` so screen readers still announce "VeilCore".
+
+### Coin artwork
+- The site currently references `stimothy.png` for square art in the hero and about sections.
+- Replace the image by dropping a new 1:1 asset into `/assets` and updating the `<img>` `src` attributes in `index.html`.
+- Provide descriptive `alt` text that matches the new artwork for accessibility.
+
+## Configuring the live embed
+
+The live section defers loading until it enters the viewport. To wire up a stream URL:
+
+```js
+// Inside script.js or an inline module
+setLive('YOUR_EMBED_URL');
+```
+
+- Call `setLive` once you know the live embed URL (e.g., Pump.fun stream), either in `script.js` or via an inline script after the page loads (`window.setLive('https://example.com/embed')`).
+- The helper stores the URL, reveals the **NOW LIVE** badge, and swaps the placeholder for an `<iframe>` as soon as the section is visible.
+- Remove or replace the placeholder note below the embed card if the stream should appear immediately on load.
+
+## Local development
+
+1. Clone the repository and switch into the project folder.
+2. Open `index.html` directly in a browser or run a lightweight server (`python -m http.server` or `npx serve`).
+3. Edit copy, links, and styles; refresh to preview updates.
+
+## Deploying to GitHub Pages (veilcore.us)
+
+1. Commit and push changes to the `main` branch.
+2. In GitHub, navigate to **Settings → Pages**.
+3. Under **Build and deployment**, choose **Deploy from a branch**, then select `main` and the root (`/`) folder.
+4. After the first deploy, set the custom domain to **veilcore.us** in the same Pages settings panel.
+5. Update DNS so `veilcore.us` points to GitHub Pages (A records `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153`, plus a `CNAME` to `<username>.github.io`).
+6. Wait for GitHub to issue the TLS certificate; confirm HTTPS works before promoting the link.
+
+### Cache-busting tips
+
+- When you ship updates, append a version query to static assets in `index.html`, e.g. `styles.css?v=2024-05-17`.
+- Alternatively, rename files (`styles.v2.css`, `script.v2.js`) so GitHub Pages serves the latest bundle without relying on stale browser caches.
+
+## License
+
+Document licensing once VeilCore finalizes distribution terms for Stimothy Pumps content.

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     rel="stylesheet"
   />
   <link rel="stylesheet" href="styles.css" />
-  <script src="script.js" defer></script>
+  <script type="module" src="script.js"></script>
 </head>
 <body class="dark">
   <a class="skip-link" href="#main">Skip to content</a>

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
         </div>
         <ul class="link-grid" role="list">
           <li>
-            <a class="link-card" href="#" target="_blank" rel="noopener">
+            <a class="link-card" href="#" target="_blank" rel="noopener noreferrer">
               <span class="link-card__icon" aria-hidden="true">◆</span>
               <div class="link-card__content">
                 <h3>Pump.fun</h3>
@@ -165,7 +165,7 @@
               class="link-card"
               href="https://x.com/veilcore"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               <span class="link-card__icon" aria-hidden="true">✶</span>
               <div class="link-card__content">
@@ -176,7 +176,7 @@
             </a>
           </li>
           <li>
-            <a class="link-card" href="#" target="_blank" rel="noopener">
+            <a class="link-card" href="#" target="_blank" rel="noopener noreferrer">
               <span class="link-card__icon" aria-hidden="true">◎</span>
               <div class="link-card__content">
                 <h3>Telegram</h3>
@@ -186,7 +186,7 @@
             </a>
           </li>
           <li>
-            <a class="link-card" href="https://github.com/veilcode/veilcode_landing" target="_blank" rel="noopener">
+            <a class="link-card" href="https://github.com/veilcode/veilcode_landing" target="_blank" rel="noopener noreferrer">
               <span class="link-card__icon" aria-hidden="true">▣</span>
               <div class="link-card__content">
                 <h3>GitHub</h3>

--- a/index.html
+++ b/index.html
@@ -176,11 +176,41 @@
             </a>
           </li>
           <li>
-            <a class="link-card" href="#" target="_blank" rel="noopener noreferrer">
+            <a
+              class="link-card"
+              href="https://t.me/stimothypumps"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <span class="link-card__icon" aria-hidden="true">◎</span>
               <div class="link-card__content">
                 <h3>Telegram</h3>
-                <p>Placeholder for the Stimothy Pumps swarm chat—drop link soon.</p>
+                <p>Join the Stimothy Pumps swarm for live drops and strategy.</p>
+              </div>
+              <span class="link-card__external" aria-hidden="true">↗</span>
+            </a>
+          </li>
+          <li>
+            <a
+              class="link-card"
+              href="https://x.com/majorleague_dev/status/1968142661879206385?s=61"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="link-card__icon" aria-hidden="true">✹</span>
+              <div class="link-card__content">
+                <h3>X Community</h3>
+                <p>Lock into the community thread driving the Stimothy lore.</p>
+              </div>
+              <span class="link-card__external" aria-hidden="true">↗</span>
+            </a>
+          </li>
+          <li>
+            <a class="link-card" href="https://conspiraai.com" target="_blank" rel="noopener noreferrer">
+              <span class="link-card__icon" aria-hidden="true">◈</span>
+              <div class="link-card__content">
+                <h3>ConspiraAI</h3>
+                <p>See how ConspiraAI keeps the glitch-feed spinning for VeilCore.</p>
               </div>
               <span class="link-card__external" aria-hidden="true">↗</span>
             </a>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>VeilCore — Stimothy Pumps ($stimothy)</title>
+  <meta
+    name="description"
+    content="VeilCore is a glitch-native studio. Stimothy Pumps ($stimothy)—a grungy, black-and-white coin built in public. Live streams, drops, and on-chain chaos."
+  />
+  <meta property="og:title" content="VeilCore — Stimothy Pumps ($stimothy)" />
+  <meta
+    property="og:description"
+    content="VeilCore is a glitch-native studio. Stimothy Pumps ($stimothy)—a grungy, black-and-white coin built in public. Live streams, drops, and on-chain chaos."
+  />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://veilcore.us/" />
+  <meta property="og:image" content="https://veilcore.us/assets/social-card.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="VeilCore — Stimothy Pumps ($stimothy)" />
+  <meta
+    name="twitter:description"
+    content="VeilCore is a glitch-native studio. Stimothy Pumps ($stimothy)—a grungy, black-and-white coin built in public. Live streams, drops, and on-chain chaos."
+  />
+  <meta name="twitter:image" content="https://veilcore.us/assets/social-card.png" />
+  <link rel="icon" href="/assets/favicon.png" type="image/png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Inter:wght@400;600&family=JetBrains+Mono:wght@500&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+  <script src="script.js" defer></script>
+</head>
+<body class="dark">
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div class="scanlines" aria-hidden="true"></div>
+
+  <header class="site-header" role="banner">
+    <div class="wrap">
+      <div class="wordmark" aria-label="VeilCore wordmark placeholder">
+        <!-- TODO: Replace with assets/veilcore-wordmark.svg -->
+        <span>VeilCore</span>
+      </div>
+      <nav id="primary-nav" class="site-nav" aria-label="Primary" data-open="false">
+        <ul>
+          <li><a href="#about">About</a></li>
+          <li><a href="#live">Live</a></li>
+          <li><a href="#token">Token</a></li>
+          <li><a href="#links">Links</a></li>
+        </ul>
+      </nav>
+      <button
+        class="mobile-nav-toggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls="primary-nav"
+        aria-label="Toggle navigation"
+      >
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+      </button>
+    </div>
+  </header>
+
+  <main id="main">
+    <section id="hero" class="wrap scanlines hero" aria-labelledby="hero-title">
+      <div class="hero__inner">
+        <div class="hero__left">
+          <h1 id="hero-title" class="glitch" data-text="Stimothy Pumps">Stimothy Pumps</h1>
+          <p class="hero__subline glitch" data-text="$stimothy">$stimothy</p>
+          <p class="hero__tagline">addicted to pump.fun — watch the chaos live</p>
+          <div class="hero__actions">
+            <a class="btn" href="#live">Watch Live</a>
+            <button class="btn-ghost" type="button" data-copy="$stimothy">Copy $stimothy</button>
+            <span class="pill-badge" id="live-badge" hidden>NOW LIVE</span>
+          </div>
+        </div>
+        <div class="hero__right">
+          <img src="stimothy.png" alt="Stimothy coin" loading="lazy" />
+        </div>
+      </div>
+    </section>
+
+    <section id="about" class="section" aria-labelledby="about-title">
+      <div class="wrap section__wrap">
+        <div class="section__content">
+          <h2 id="about-title">What is VeilCore?</h2>
+          <p>
+            VeilCore is a glitch-native, creator-first studio. We design coins, streams, and moments that feel wired into the feed. Our mascot, Stimothy, is addicted to pump.fun—and we build around the spectacle.
+          </p>
+          <p>
+            This site is the hub: live streams, drops, and progress—built in public. No promises, no financial advice. Just raw output and culture.
+          </p>
+          <ul class="section__list">
+            <li>Live trading stream</li>
+            <li>Creator rewards focus</li>
+            <li>No commentary, no mercy</li>
+          </ul>
+        </div>
+        <figure class="section__visual">
+          <img src="stimothy.png" alt="Stimothy coin" loading="lazy" />
+        </figure>
+      </div>
+    </section>
+
+    <section id="live" class="section live" aria-labelledby="live-title">
+      <div class="wrap live__wrap">
+        <h2 id="live-title">Live on pump.fun</h2>
+        <div class="live__frame" id="live-embed" data-live-target>
+          <div class="live__placeholder" role="img" aria-label="Live stream placeholder">
+            <span class="live__play" aria-hidden="true"></span>
+          </div>
+        </div>
+        <p class="live__note">Stream appears here when live.</p>
+      </div>
+    </section>
+
+    <section id="token" class="section token" aria-labelledby="token-title">
+      <div class="wrap token__wrap">
+        <h2 id="token-title">$stimothy</h2>
+        <div class="ticker" aria-label="$stimothy ticker">
+          <div class="ticker__inner" aria-hidden="true">
+            $stimothy • addicted to pump.fun • stay unhinged • $stimothy • addicted to pump.fun • stay unhinged •
+          </div>
+        </div>
+        <ul class="token-cards" role="list">
+          <li class="token-card">
+            <h3>Contract</h3>
+            <p>Coming soon</p>
+          </li>
+          <li class="token-card">
+            <h3>Liquidity</h3>
+            <p>TBA</p>
+          </li>
+          <li class="token-card">
+            <h3>Creator rewards</h3>
+            <p>Stream-driven culture; we reward the spectacle. Details soon.</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="links" class="section" aria-labelledby="links-title">
+      <div class="wrap">
+        <div class="section__header">
+          <p class="pill-badge" aria-hidden="true">Quick links</p>
+          <h2 id="links-title">Plug into the grid</h2>
+        </div>
+        <ul class="link-grid" role="list">
+          <li>
+            <a class="link-card" href="#" target="_blank" rel="noopener">
+              <span class="link-card__icon" aria-hidden="true">◆</span>
+              <div class="link-card__content">
+                <h3>Pump.fun</h3>
+                <p>Placeholder jump point for the Stimothy Pumps launch page.</p>
+              </div>
+              <span class="link-card__external" aria-hidden="true">↗</span>
+            </a>
+          </li>
+          <li>
+            <a
+              class="link-card"
+              href="https://x.com/veilcore"
+              target="_blank"
+              rel="noopener"
+            >
+              <span class="link-card__icon" aria-hidden="true">✶</span>
+              <div class="link-card__content">
+                <h3>X / Twitter</h3>
+                <p>Tap into the VeilCore signal for real-time Stimothy chaos.</p>
+              </div>
+              <span class="link-card__external" aria-hidden="true">↗</span>
+            </a>
+          </li>
+          <li>
+            <a class="link-card" href="#" target="_blank" rel="noopener">
+              <span class="link-card__icon" aria-hidden="true">◎</span>
+              <div class="link-card__content">
+                <h3>Telegram</h3>
+                <p>Placeholder for the Stimothy Pumps swarm chat—drop link soon.</p>
+              </div>
+              <span class="link-card__external" aria-hidden="true">↗</span>
+            </a>
+          </li>
+          <li>
+            <a class="link-card" href="https://github.com/veilcode/veilcode_landing" target="_blank" rel="noopener">
+              <span class="link-card__icon" aria-hidden="true">▣</span>
+              <div class="link-card__content">
+                <h3>GitHub</h3>
+                <p>Review the repo powering veilcore.us and ship fresh glitches.</p>
+              </div>
+              <span class="link-card__external" aria-hidden="true">↗</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer" role="contentinfo">
+    <div class="wrap footer__wrap">
+      <p class="footer__legal">
+        © VeilCore <span id="current-year"></span>
+        <span aria-hidden="true">•</span>
+        <span class="footer__domain">veilcore.us</span>
+      </p>
+      <nav aria-label="Legal">
+        <ul class="footer__nav">
+          <li><a href="#">Terms</a></li>
+          <li><a href="#">Privacy</a></li>
+          <li><a href="#">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </footer>
+
+  <div class="toast" role="status" aria-live="polite" hidden>$stimothy copied!</div>
+
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,274 @@
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+const initSmoothScroll = () => {
+  const scrollTargets = document.querySelectorAll('a[href^="#"], [data-scroll]');
+
+  scrollTargets.forEach((trigger) => {
+    trigger.addEventListener('click', (event) => {
+      const selector = trigger.dataset.scroll || trigger.getAttribute('href');
+      if (!selector || selector === '#' || selector.length <= 1) return;
+
+      const target = document.querySelector(selector);
+      if (!target) return;
+
+      event.preventDefault();
+
+      const scrollOptions = {
+        behavior: prefersReducedMotion.matches ? 'auto' : 'smooth',
+        block: 'start',
+      };
+
+      target.scrollIntoView(scrollOptions);
+      target.setAttribute('tabindex', '-1');
+      target.focus({ preventScroll: true });
+      target.addEventListener(
+        'blur',
+        () => {
+          if (target.getAttribute('tabindex') === '-1') {
+            target.removeAttribute('tabindex');
+          }
+        },
+        { once: true }
+      );
+    });
+  });
+};
+
+const initMobileNav = () => {
+  const toggle = document.querySelector('.mobile-nav-toggle');
+  const nav = document.getElementById('primary-nav');
+
+  if (!toggle || !nav) return;
+
+  const closeNav = () => {
+    nav.dataset.open = 'false';
+    toggle.setAttribute('aria-expanded', 'false');
+  };
+
+  toggle.addEventListener('click', () => {
+    const isOpen = nav.dataset.open === 'true';
+    nav.dataset.open = String(!isOpen);
+    toggle.setAttribute('aria-expanded', String(!isOpen));
+  });
+
+  nav.addEventListener('click', (event) => {
+    if (event.target instanceof Element && event.target.closest('a')) {
+      closeNav();
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 768) {
+      closeNav();
+    }
+  });
+};
+
+const initCopyTicker = () => {
+  const TICKER_VALUE = '$stimothy';
+  const copyButtons = document.querySelectorAll('[data-copy="$stimothy"]');
+  const toast = document.querySelector('.toast');
+
+  if (!copyButtons.length) return;
+
+  const showToast = (message) => {
+    if (!toast) return;
+
+    toast.textContent = message;
+    toast.hidden = false;
+
+    window.clearTimeout(showToast.timeoutId);
+    window.clearTimeout(showToast.hideTimeoutId);
+
+    requestAnimationFrame(() => {
+      toast.classList.add('is-visible');
+    });
+
+    showToast.timeoutId = window.setTimeout(() => {
+      toast.classList.remove('is-visible');
+      showToast.hideTimeoutId = window.setTimeout(() => {
+        toast.hidden = true;
+      }, 220);
+    }, 1400);
+  };
+
+  copyButtons.forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      if (!navigator.clipboard) {
+        showToast('Copy not available');
+        return;
+      }
+
+      try {
+        await navigator.clipboard.writeText(TICKER_VALUE);
+        showToast('Copied $stimothy');
+      } catch (error) {
+        console.error('Clipboard copy failed', error);
+        showToast('Copy not available');
+      }
+    });
+  });
+};
+
+let EMBED_URL = '';
+let liveSectionPrimed = false;
+let embedLoaded = false;
+
+const initLive = () => {
+  if (embedLoaded || !EMBED_URL) return;
+
+  const placeholder = document.getElementById('live-embed') || document.querySelector('[data-live-target]');
+  if (!placeholder) return;
+
+  const iframe = document.createElement('iframe');
+  iframe.src = EMBED_URL;
+  iframe.title = 'Live stream';
+  iframe.loading = 'lazy';
+  iframe.allow = 'autoplay; encrypted-media; picture-in-picture';
+  iframe.setAttribute('allowfullscreen', '');
+  iframe.className = placeholder.className;
+  if (placeholder.id) {
+    iframe.id = placeholder.id;
+  }
+
+  placeholder.replaceWith(iframe);
+  embedLoaded = true;
+
+  const liveNote = document.querySelector('.live__note');
+  if (liveNote) {
+    liveNote.textContent = 'Streaming live now.';
+    liveNote.classList.add('is-live');
+  }
+};
+
+const observeLiveSection = () => {
+  const liveSection = document.getElementById('live');
+  if (!liveSection) return;
+
+  const primeAndInit = () => {
+    liveSectionPrimed = true;
+    initLive();
+  };
+
+  if (typeof IntersectionObserver === 'undefined') {
+    primeAndInit();
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries, entryObserver) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+
+        entryObserver.disconnect();
+        primeAndInit();
+      });
+    },
+    {
+      threshold: 0.2,
+      rootMargin: '0px 0px -15% 0px',
+    }
+  );
+
+  observer.observe(liveSection);
+};
+
+const glitchTimers = new WeakMap();
+
+const clearGlitchTimers = (element) => {
+  const timers = glitchTimers.get(element);
+  if (!timers) return;
+
+  if (timers.delay) {
+    window.clearTimeout(timers.delay);
+  }
+  if (timers.cleanup) {
+    window.clearTimeout(timers.cleanup);
+  }
+
+  glitchTimers.delete(element);
+};
+
+const scheduleGlitchBurst = (element) => {
+  if (prefersReducedMotion.matches) return;
+
+  const delay = 8000 + Math.random() * 6000;
+  const delayTimeout = window.setTimeout(() => {
+    element.classList.add('animate');
+
+    const cleanupTimeout = window.setTimeout(() => {
+      element.classList.remove('animate');
+      clearGlitchTimers(element);
+      scheduleGlitchBurst(element);
+    }, 260);
+
+    glitchTimers.set(element, { delay: null, cleanup: cleanupTimeout });
+  }, delay);
+
+  glitchTimers.set(element, { delay: delayTimeout, cleanup: null });
+};
+
+const initGlitchBursts = () => {
+  if (prefersReducedMotion.matches) return;
+
+  const glitchElements = document.querySelectorAll('.glitch');
+  glitchElements.forEach((element) => {
+    clearGlitchTimers(element);
+    scheduleGlitchBurst(element);
+  });
+};
+
+const stopGlitchBursts = () => {
+  const glitchElements = document.querySelectorAll('.glitch');
+  glitchElements.forEach((element) => {
+    clearGlitchTimers(element);
+    element.classList.remove('animate');
+  });
+};
+
+const setYear = () => {
+  const yearSlot = document.getElementById('current-year');
+  if (yearSlot) {
+    yearSlot.textContent = new Date().getFullYear();
+  }
+};
+
+const setLive = (url) => {
+  EMBED_URL = typeof url === 'string' ? url : '';
+  const badge = document.getElementById('live-badge');
+  if (badge) {
+    badge.removeAttribute('hidden');
+  }
+
+  if (liveSectionPrimed) {
+    initLive();
+  }
+};
+
+const handleMotionPreferenceChange = (event) => {
+  if (event.matches) {
+    stopGlitchBursts();
+  } else {
+    initGlitchBursts();
+    if (liveSectionPrimed) {
+      initLive();
+    }
+  }
+};
+
+if (typeof prefersReducedMotion.addEventListener === 'function') {
+  prefersReducedMotion.addEventListener('change', handleMotionPreferenceChange);
+} else if (typeof prefersReducedMotion.addListener === 'function') {
+  prefersReducedMotion.addListener(handleMotionPreferenceChange);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  initSmoothScroll();
+  initCopyTicker();
+  initMobileNav();
+  observeLiveSection();
+  initGlitchBursts();
+  setYear();
+});
+
+window.setLive = setLive;

--- a/script.js
+++ b/script.js
@@ -233,7 +233,7 @@ const setYear = () => {
   }
 };
 
-const setLive = (url) => {
+export function setLive(url) {
   EMBED_URL = typeof url === 'string' ? url : '';
   const badge = document.getElementById('live-badge');
   if (badge) {
@@ -243,7 +243,7 @@ const setLive = (url) => {
   if (liveSectionPrimed) {
     initLive();
   }
-};
+}
 
 const handleMotionPreferenceChange = (event) => {
   if (event.matches) {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,954 @@
+/*
+  VeilCore / Stimothy Pumps Landing Styles
+  Grungy monochrome glitchcore theme with subtle neon pill accents
+*/
+
+/* =======================
+   CSS Variables & Base
+   ======================= */
+:root {
+  --bg: #0a0a0a;
+  --ink: #f2f2f2;
+  --mute: #9a9a9a;
+  --grit: rgba(255, 255, 255, 0.04);
+  --pill: #a6f4a0;
+  --border-soft: 1px solid rgb(255 255 255 / 0.08);
+  --wrap-max: 1200px;
+  --radius: 18px;
+  font-size: clamp(15px, 0.85vw + 0.85rem, 18px);
+  color-scheme: dark;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: 'Inter', system-ui, sans-serif;
+  font-weight: 400;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  position: relative;
+}
+
+img,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: none;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+}
+
+button {
+  cursor: pointer;
+}
+
+ul,
+ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+h1,
+h2,
+h3 {
+  font-family: 'Archivo Black', 'Inter', system-ui, sans-serif;
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: 0.02em;
+  margin: 0 0 0.75em;
+}
+
+h1 {
+  font-size: clamp(3rem, 6vw, 4.5rem);
+  letter-spacing: -0.025em;
+}
+
+h2 {
+  font-size: clamp(2rem, 4vw, 3.2rem);
+}
+
+h3 {
+  font-size: clamp(1.2rem, 2.4vw, 1.6rem);
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 1em;
+}
+
+main {
+  display: block;
+}
+
+/* =======================
+   Layout Helpers
+   ======================= */
+.wrap {
+  width: min(100% - 3rem, var(--wrap-max));
+  margin-inline: auto;
+}
+
+.section {
+  padding-block: clamp(4rem, 9vw, 7rem);
+}
+
+.section__wrap {
+  display: grid;
+  gap: clamp(2rem, 5vw, 4rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.section__list {
+  display: grid;
+  gap: 0.75rem;
+  font-family: 'JetBrains Mono', monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.section__list li {
+  position: relative;
+  padding-left: 1.35rem;
+}
+
+.section__list li::before {
+  content: '•';
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  color: var(--mute);
+}
+
+.section__visual {
+  position: relative;
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: var(--border-soft);
+  background: rgb(255 255 255 / 0.02);
+  box-shadow: 0 18px 48px rgb(0 0 0 / 0.55);
+}
+
+.section__visual img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+
+.section__visual figcaption {
+  padding: 0.85rem 1.1rem 1.2rem;
+  color: var(--mute);
+  font-size: 0.9rem;
+}
+
+.section__header {
+  max-width: 46ch;
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: clamp(2rem, 5vw, 3rem);
+}
+
+/* =======================
+   Accessibility
+   ======================= */
+.skip-link {
+  position: absolute;
+  inset-inline: 50%;
+  transform: translateX(-50%);
+  inset-block-start: -999px;
+  background: var(--ink);
+  color: var(--bg);
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  z-index: 1200;
+}
+
+.skip-link:focus-visible {
+  inset-block-start: 1.5rem;
+}
+
+:focus-visible {
+  outline: 2px solid var(--pill);
+  outline-offset: 3px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* =======================
+   Atmosphere Effects
+   ======================= */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at center, transparent 20%, rgb(0 0 0 / 0.6) 80%),
+    repeating-linear-gradient(0deg, rgb(255 255 255 / 0.02) 0 1px, transparent 2px 4px);
+  mix-blend-mode: soft-light;
+  opacity: 0.6;
+  z-index: 1000;
+  animation: grain 10s steps(10) infinite;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 850;
+}
+
+.scanlines::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.08;
+  background: repeating-linear-gradient(180deg, rgba(0, 0, 0, 0) 0 2px, rgba(255, 255, 255, 0.07) 3px 3px);
+}
+
+@keyframes grain {
+  0% {
+    transform: translate(0, 0);
+  }
+  25% {
+    transform: translate(1%, -0.5%);
+  }
+  50% {
+    transform: translate(-1%, 0.5%);
+  }
+  75% {
+    transform: translate(0.5%, 1%);
+  }
+  100% {
+    transform: translate(0, 0);
+  }
+}
+
+/* =======================
+   Utilities
+   ======================= */
+.pill-badge {
+  display: inline-flex;
+  gap: 0.5ch;
+  align-items: center;
+  font: 600 0.8rem/1.8 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  padding: 0.1rem 0.6rem;
+  border: 1px solid rgb(255 255 255 / 0.12);
+  border-radius: 999px;
+  color: #0b180e;
+  background: var(--pill);
+  box-shadow: 0 0 0 0.5px #000 inset;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.glitch {
+  position: relative;
+  display: inline-block;
+  filter: contrast(1.1);
+}
+
+.glitch::before,
+.glitch::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  color: var(--ink);
+  mix-blend-mode: screen;
+  opacity: 0.8;
+  clip-path: inset(0 0 0 0);
+}
+
+.glitch::before {
+  transform: translate(0.5px, -0.5px);
+  filter: drop-shadow(0 0 2px rgb(255 255 255 / 0.45));
+}
+
+.glitch::after {
+  transform: translate(-0.5px, 0.5px);
+  filter: blur(0.2px) brightness(0.95);
+}
+
+.glitch.animate {
+  animation: glitch-jump 12s steps(1) infinite;
+}
+
+.acid:hover {
+  text-shadow: 0 0 0.6rem rgb(255 255 255 / 0.5), 0 0 1.2rem rgb(255 255 255 / 0.25);
+  filter: contrast(1.2);
+}
+
+@keyframes glitch-jump {
+  0%,
+  92%,
+  100% {
+    transform: translate(0, 0);
+  }
+  93% {
+    transform: translate(2px, -1px);
+  }
+  94% {
+    transform: translate(-2px, 1px);
+  }
+  95% {
+    transform: translate(1px, 0);
+  }
+  96% {
+    transform: translate(-1px, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glitch.animate {
+    animation: none;
+  }
+
+  body::before {
+    animation: none;
+  }
+
+  .ticker__inner {
+    animation: none;
+  }
+}
+
+.btn,
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6ch;
+  padding: 0.95rem 1.25rem;
+  border-radius: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  transition: transform 0.12s ease, filter 0.12s ease, border-color 0.12s ease;
+}
+
+.btn {
+  background: var(--ink);
+  color: var(--bg);
+  border: 1px solid rgb(255 255 255 / 0.15);
+  box-shadow: 0 18px 30px rgb(0 0 0 / 0.35);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+  filter: contrast(1.12);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid rgb(255 255 255 / 0.18);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus-visible {
+  border-color: rgb(255 255 255 / 0.36);
+  transform: translateY(-1px);
+}
+
+.ticker {
+  overflow: hidden;
+  white-space: nowrap;
+  mask-image: linear-gradient(90deg, transparent, #000 10%, #000 90%, transparent);
+}
+
+.ticker__inner {
+  display: inline-flex;
+  gap: 1.5rem;
+  align-items: center;
+  padding-block: 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  animation: ticker 18s linear infinite;
+}
+
+@keyframes ticker {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.toast {
+  position: fixed;
+  inset-inline: 50%;
+  inset-block-end: 3.5rem;
+  transform: translateX(-50%) translateY(30px);
+  padding: 0.75rem 1.35rem;
+  border-radius: 999px;
+  background: rgb(15 15 15 / 0.9);
+  color: var(--ink);
+  border: 1px solid rgb(255 255 255 / 0.15);
+  font-family: 'JetBrains Mono', monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s linear;
+  z-index: 1100;
+}
+
+.toast.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* =======================
+   Header
+   ======================= */
+.site-header {
+  position: sticky;
+  inset-block-start: 0;
+  z-index: 800;
+  background: rgb(10 10 10 / 0.78);
+  backdrop-filter: blur(12px);
+  border-bottom: var(--border-soft);
+}
+
+.site-header .wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding-block: 1.25rem;
+}
+
+.wordmark {
+  font-family: 'Archivo Black', system-ui, sans-serif;
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.site-nav ul {
+  display: flex;
+  gap: clamp(1rem, 3vw, 1.75rem);
+}
+
+.site-nav a {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding-block: 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mute);
+  font-size: 0.85rem;
+  transition: color 0.18s ease;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  inset-block-end: -0.45rem;
+  height: 2px;
+  background: rgb(255 255 255 / 0.6);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 0.2s ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+  color: var(--ink);
+}
+
+.site-nav a:hover::after,
+.site-nav a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.mobile-nav-toggle {
+  display: none;
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgb(255 255 255 / 0.18);
+  background: rgb(255 255 255 / 0.04);
+}
+
+.mobile-nav-toggle span {
+  position: absolute;
+  inset-inline: 11px;
+  height: 2px;
+  background: var(--ink);
+  border-radius: 999px;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.mobile-nav-toggle span:nth-child(1) {
+  inset-block-start: 14px;
+}
+
+.mobile-nav-toggle span:nth-child(2) {
+  inset-block-start: 21px;
+}
+
+.mobile-nav-toggle span:nth-child(3) {
+  inset-block-start: 28px;
+}
+
+.mobile-nav-toggle[aria-expanded='true'] span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.mobile-nav-toggle[aria-expanded='true'] span:nth-child(2) {
+  opacity: 0;
+}
+
+.mobile-nav-toggle[aria-expanded='true'] span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+/* =======================
+   Hero
+   ======================= */
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding-block: clamp(6rem, 12vw, 10rem);
+  background:
+    radial-gradient(circle at 12% 10%, rgb(255 255 255 / 0.08), transparent 55%),
+    radial-gradient(circle at 84% 28%, rgb(255 255 255 / 0.06), transparent 60%),
+    linear-gradient(135deg, rgb(6 6 6), rgb(12 12 12));
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgb(255 255 255 / 0.08), transparent 60%);
+  mix-blend-mode: soft-light;
+  opacity: 0.18;
+  z-index: 0;
+}
+
+.hero__wrap {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(3rem, 6vw, 5rem);
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.hero__subline {
+  font-family: 'JetBrains Mono', monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  margin-bottom: 0.85rem;
+}
+
+.hero__tagline {
+  color: var(--mute);
+  font-size: clamp(1rem, 2.4vw, 1.15rem);
+  max-width: 46ch;
+  margin-bottom: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero__visual {
+  position: relative;
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid rgb(255 255 255 / 0.12);
+  background: linear-gradient(140deg, rgb(16 16 16), rgb(4 4 4));
+  box-shadow: 0 28px 60px rgb(0 0 0 / 0.6);
+  max-width: 420px;
+  justify-self: center;
+}
+
+.hero__visual::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, transparent 35%, rgb(255 255 255 / 0.08));
+  mix-blend-mode: screen;
+}
+
+/* =======================
+   Live Section
+   ======================= */
+.live {
+  background: linear-gradient(160deg, rgb(12 12 12), rgb(4 4 4));
+}
+
+.live__wrap {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.live__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.live__status {
+  font-size: 0.7rem;
+}
+
+.live__frame {
+  position: relative;
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: var(--border-soft);
+  background: rgb(255 255 255 / 0.03);
+  aspect-ratio: 16 / 9;
+  display: grid;
+  place-items: center;
+}
+
+.live__placeholder {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  background:
+    repeating-linear-gradient(135deg, rgb(255 255 255 / 0.04) 0 1px, transparent 1px 3px),
+    linear-gradient(135deg, rgb(14 14 14), rgb(5 5 5));
+}
+
+.live__play {
+  width: 3.4rem;
+  aspect-ratio: 1;
+  border: 2px solid rgb(255 255 255 / 0.35);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.live__play::after {
+  content: '';
+  position: absolute;
+  border-style: solid;
+  border-width: 12px 0 12px 18px;
+  border-color: transparent transparent transparent var(--ink);
+  inset-inline-start: 55%;
+  transform: translateX(-50%);
+}
+
+.live__placeholder-text {
+  margin-top: 1rem;
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--mute);
+  font-size: 0.8rem;
+}
+
+.live__note {
+  color: var(--mute);
+  font-size: 0.9rem;
+}
+
+/* =======================
+   Token Section
+   ======================= */
+.token {
+  background: linear-gradient(150deg, rgb(8 8 8), rgb(3 3 3));
+}
+
+.token__wrap {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.token__header {
+  display: grid;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.token__ticker {
+  border-radius: 999px;
+  padding: 0.2rem;
+  border: 1px solid rgb(255 255 255 / 0.12);
+  background: rgb(255 255 255 / 0.04);
+}
+
+.token__ticker .ticker__inner {
+  font-size: 0.78rem;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.token-cards {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.token-card {
+  border-radius: var(--radius);
+  border: var(--border-soft);
+  padding: 1.75rem;
+  background: linear-gradient(145deg, rgb(255 255 255 / 0.04), rgb(0 0 0 / 0.55));
+  display: grid;
+  gap: 0.75rem;
+}
+
+.token-card h3 {
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.token-card p {
+  color: var(--mute);
+  margin: 0;
+}
+
+/* =======================
+   Links Section
+   ======================= */
+.link-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.link-card {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.85rem, 2vw, 1.4rem);
+  padding: clamp(1.75rem, 3vw, 2.2rem);
+  border-radius: var(--radius);
+  border: var(--border-soft);
+  background: linear-gradient(135deg, rgb(255 255 255 / 0.04), rgb(0 0 0 / 0.6));
+  transition: transform 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+  color: var(--mute);
+}
+
+.link-card__icon {
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  aspect-ratio: 1;
+  border-radius: 0.75rem;
+  background: rgb(255 255 255 / 0.12);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.35rem;
+}
+
+.link-card__content {
+  flex: 1;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.link-card__content h3 {
+  margin: 0;
+  color: var(--ink);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 1rem;
+}
+
+.link-card__content p {
+  margin: 0;
+  color: var(--mute);
+  font-size: 0.9rem;
+}
+
+.link-card__external {
+  font-size: 1.2rem;
+  color: var(--ink);
+}
+
+.link-card:hover,
+.link-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgb(255 255 255 / 0.25);
+  color: var(--ink);
+}
+
+/* =======================
+   Footer
+   ======================= */
+.site-footer {
+  padding-block: 2.5rem;
+  border-top: var(--border-soft);
+  background: rgb(8 8 8 / 0.95);
+}
+
+.footer__wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.footer__legal {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--mute);
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.footer__domain {
+  color: var(--ink);
+}
+
+.footer__nav {
+  display: flex;
+  gap: 1.25rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.footer__nav a {
+  color: var(--mute);
+}
+
+.footer__nav a:hover,
+.footer__nav a:focus-visible {
+  color: var(--ink);
+}
+
+/* =======================
+   Responsive
+   ======================= */
+@media (max-width: 768px) {
+  .site-nav {
+    position: absolute;
+    inset-inline-end: 1.5rem;
+    inset-block-start: calc(100% + 0.75rem);
+    padding: 1.2rem;
+    border-radius: 14px;
+    border: var(--border-soft);
+    background: rgb(10 10 10 / 0.95);
+    backdrop-filter: blur(14px);
+    transform-origin: top right;
+    transform: scale(0.94);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s linear;
+  }
+
+  .site-nav[data-open='true'] {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+  }
+
+  .site-nav ul {
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  .mobile-nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 540px) {
+  .wrap {
+    width: min(100% - 2rem, var(--wrap-max));
+  }
+
+  .hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .footer__wrap {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+/* =======================
+   Motion Preferences
+   ======================= */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .glitch.animate {
+    animation: none;
+  }
+
+  body::before {
+    animation: none;
+  }
+
+  .ticker__inner {
+    animation: none;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -578,7 +578,7 @@ body::before {
   z-index: 0;
 }
 
-.hero__wrap {
+.hero__inner {
   position: relative;
   z-index: 1;
   display: grid;
@@ -607,7 +607,7 @@ body::before {
   gap: 1rem;
 }
 
-.hero__visual {
+.hero__right {
   position: relative;
   border-radius: var(--radius);
   overflow: hidden;
@@ -618,12 +618,19 @@ body::before {
   justify-self: center;
 }
 
-.hero__visual::after {
+.hero__right::after {
   content: '';
   position: absolute;
   inset: 0;
   background: linear-gradient(135deg, transparent 35%, rgb(255 255 255 / 0.08));
   mix-blend-mode: screen;
+}
+
+.hero__right img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  aspect-ratio: 1 / 1;
 }
 
 /* =======================


### PR DESCRIPTION
## Summary
- refresh landing copy and metadata for VeilCore and Stimothy Pumps, including the glitch hero, about story, token ticker, and updated external links
- wire the live section placeholder to a lazy iframe mount with a reusable `setLive` badge toggle plus smooth scrolling, glitch pulses, and resilient clipboard toast behavior
- align the glitchcore styling with the monochrome override: grain/scanlines, revised glitch utility, pill accents, reduced-motion guards, and neon button tweaks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca571ed8c8833196e50f0c4b6995f5